### PR TITLE
Fixing the calculations for take_home_amounts to include incomes_afte…

### DIFF
--- a/uk_tax_23-24.py
+++ b/uk_tax_23-24.py
@@ -105,7 +105,8 @@ def calculate_taxes(incomes, pension_contrib_percent=0, voluntary_pension_contri
         student_loan_repayments = student_loan_repayment_plan_2(incomes)
 
     combined_taxes = income_taxes + national_insurances + student_loan_repayments
-    take_home_amounts = incomes - combined_taxes
+    # Need to account for any pension_contributions taken off here, if we've passed in a value
+    take_home_amounts = incomes_after_pension - combined_taxes
 
     return tax_20, tax_40, tax_45, national_insurances, combined_taxes, take_home_amounts, student_loan_repayments
 


### PR DESCRIPTION
…r_pension (if that has been calculated by passing in a new pension contribution percent value from print_tax_breakdown()), as otherwise the values that get output don't include it correctly.